### PR TITLE
Finder support for dev/service tokens

### DIFF
--- a/src/Finder.ts
+++ b/src/Finder.ts
@@ -10,6 +10,7 @@ export type FinderOptions = {
     autoClose?: boolean;
     filters?: FinderFilters;
     permanentDownloadUrls?: boolean;
+    serviceToken?: string
 };
 
 type FinderFilters = FinderFilter[] | [];


### PR DESCRIPTION
Added ability to include a serviceToken in options, as a second means to authenticate

Not sure if frontify is accepting PRs but this is a common function for private apps & is a usecase for our client, so would be nice to have on the main branch rather than a forked, recompiled version. 