### PR TITLE
Use nvmrc node version for GitHub registry as well.

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -72,11 +72,11 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Use Node.js 16 (GitHub repository)
-              uses: actions/setup-node@v2
+            - name: Use Node.js (GitHub repository)
+              uses: actions/setup-node@v4
               with:
+                  node-version-file: '.nvmrc'
                   registry-url: 'https://npm.pkg.github.com'
-                  node-version: 16
 
             - name: Publish to GitHub Packages
               run: npm publish --access public


### PR DESCRIPTION
This one also uses the nvmrc node version for the GitHub registry publication.
It was prob left out while migrating the other.
