### PR TITLE
Bump to version 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@frontify/frontify-finder",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@frontify/frontify-finder",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Authenticate, search and access Frontify assets data from any secure web app.",
     "files": [
         "dist/**/*"


### PR DESCRIPTION
Bump version from 2.1.0 -> 2.2.0
- Release `thumbnailUrl` to supported `Asset` types