### PR TITLE
feat: Add alt text field to the asset type

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -52,6 +52,7 @@ export type FrontifyAsset = {
     type: string;
     author: string | null;
     expiresAt: string | null;
+    alternativeText: string | null;
     licenses:
         | {
               title: string;
@@ -111,6 +112,7 @@ query AssetByIds($ids: [ID!]!, $permanent: Boolean!) {
     }
     createdAt
     expiresAt
+    alternativeText
     ...withMetadata
     ...onImage
     ...onDocument


### PR DESCRIPTION
Adds the `alternativeText` to the returend asset type.
