### PR TITLE
ci: tag prereleases on npm publish

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -53,4 +53,4 @@ jobs:
               run: npm run build
 
             - name: Publish to npm
-              run: npm publish --access public
+              run: npm publish --access public --tag ${{ github.event.release.prerelease && 'beta' || 'latest' }}


### PR DESCRIPTION
same fix as Authenticator while releasing a beta version.

avoiding getting that same issue:
`npm error You must specify a tag using --tag when publishing a prerelease version.`