### PR TITLE
feat(DnD): Restrict dropping on iframe

### DIFF
--- a/src/Finder.ts
+++ b/src/Finder.ts
@@ -237,7 +237,13 @@ export class FrontifyFinder {
 
         const { x, y } = this.mapToHostCoordinates(coordinates);
         const ownerDocument = this.parentNode?.ownerDocument ?? document;
-        const dropZone = this.resolveDropZone(ownerDocument.elementFromPoint(x, y));
+        const target = ownerDocument.elementFromPoint(x, y);
+
+        if (target === this.iFrame) {
+            return;
+        }
+
+        const dropZone = this.resolveDropZone(target);
 
         if (!dropZone) {
             return;


### PR DESCRIPTION
Don't fire a drop when the asset is released over the Finder iframe itself. If the asset is dropped over the Finder iframe, it should be consider as cancelled action.